### PR TITLE
Updates to new SASS color module syntax

### DIFF
--- a/src/components/Carousel.module.scss
+++ b/src/components/Carousel.module.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @use "../assets/variables" as *;
 @use "../assets/mixins" as *;
 // Carousel swipe tipo wireframe
@@ -65,7 +66,7 @@
   outline: none;
 }
 .arrow:hover, .arrow:focus {
-  background: adjust-color($primary-color, $lightness: 15%);
+  background: color.adjust($primary-color, $lightness: 15%);
   box-shadow: 0 4px 16px #0003, 0 0 0 2.5px $primary-color inset;
   transform: scale(1.08);
 }

--- a/src/components/Closet.module.scss
+++ b/src/components/Closet.module.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @use "../assets/variables" as *;
 @use "../assets/mixins" as *;
 .categoryContainer {
@@ -56,7 +57,7 @@
   transition: $transition;
 }
 .deleteBtn:hover {
-  background: adjust-color($danger-color, $lightness: 10%);
+  background: $danger-color;
 }
 
 .deleteModal {

--- a/src/components/ConfirmLogoutModal.module.scss
+++ b/src/components/ConfirmLogoutModal.module.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @use "../assets/variables" as *;
 @use "../assets/mixins" as *;
 .overlay {
@@ -84,5 +85,5 @@
   transition: $transition;
 }
 .confirmBtn:hover {
-  background: adjust-color($primary-color, $lightness: 15%);
+  background: color.adjust($primary-color, $lightness: 15%);
 }

--- a/src/components/ConfirmarCombinacion.module.scss
+++ b/src/components/ConfirmarCombinacion.module.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @use "../assets/variables" as *;
 
 .modalOverlay {
@@ -148,6 +149,6 @@
   color: #181818;
 
   &:hover {
-  background: adjust-color($primary-color, $lightness: 10%);
+  background: color.adjust($primary-color, $lightness: 10%);
   }
 }

--- a/src/components/Login.module.scss
+++ b/src/components/Login.module.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @use "../assets/variables" as *;
 @use "../assets/mixins" as *;
 
@@ -56,7 +57,7 @@
   transition: $transition;
 }
 .loginContainer button:hover {
-  background: linear-gradient(90deg, adjust-color($primary-color, $lightness: 15%) 60%, #232323 100%);
+  background: linear-gradient(90deg, color.adjust($primary-color, $lightness: 15%) 60%, #232323 100%);
 }
 
 

--- a/src/components/Navbar.module.scss
+++ b/src/components/Navbar.module.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @use "../assets/variables" as *;
 @use "../assets/mixins" as *;
 
@@ -85,7 +86,7 @@
 }
 
 .logoutBtn:hover {
-  background: adjust-color($danger-color, $lightness: 10%);
+  background: color.adjust($danger-color, $lightness: 10%);
 }
 
 .menuBtn,


### PR DESCRIPTION
Updates the codebase to use the new SASS color module syntax.

The `adjust-color` function is deprecated and replaced with `color.adjust` for improved compatibility with future SASS versions. Also, using the `sass:color` module makes the intention more explicit.